### PR TITLE
Renamings, Fs to check if siad.path exists, and some documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,16 @@ Should log something like:
 null '0.4.8'
 ```
 
+The call object passed as the first argument into call() are funneled directly
+into the [`request`](https://github.com/request/request) library, so checkout
+[their options](https://github.com/request/request#requestoptions-callback) to
+see how to access the full functionality of [Sia's
+API](https://github.com/NebulousLabs/Sia/blob/master/doc/API.md)
+
 ```js
 Siad.call({
   url: '/consensus/block',
+  method: 'GET',
   qs: {
     height: 0
   }
@@ -64,7 +71,3 @@ null { block:
    minerpayouts: null,
    transactions: [ [Object] ] } }
 ```
-
-## License
-
-[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # [![Sia Logo](http://sia.tech/resources/img/svg/sia-green-logo.svg)](http://sia.tech/) Nodejs Wrapper
 
+[![Build Status](https://travis-ci.org/NebulousLabs/Nodejs-Sia.svg?branch=master)](https://travis-ci.org/NebulousLabs/Nodejs-Sia)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 [![devDependency Status](https://david-dm.org/NebulousLabs/Nodejs-Sia/dev-status.svg)](https://david-dm.org/NebulousLabs/Nodejs-Sia#info=devDependencies)
 [![dependencies Status](https://david-dm.org/NebulousLabs/Nodejs-Sia.svg)](https://david-dm.org/NebulousLabs/Nodejs-Sia#info=dependencies)

--- a/README.md
+++ b/README.md
@@ -17,18 +17,52 @@ requests.
 
 - [node & npm](https://nodejs.org/download/)
 
-## Installing
+## Installation
 
-We'll publish this soon to make installation as easy as
+Run the following to save sia.js in your project's `node_modules` folder
 
 ```bash
-npm install sia.js
+npm install -S sia.js
 ```
 
-and used in code via
+## Usage
 
 ```js
-var Sia = require('sia.js');
+var Siad = require('sia.js')
+```
+
+```js
+Siad.call('/daemon/version', function(err, result) {
+  console.log(err, result)
+})
+```
+
+Should log something like:
+
+```bash
+null '0.4.8'
+```
+
+```js
+Siad.call({
+  url: '/consensus/block',
+  qs: {
+    height: 0
+  }
+}, function(err,result) {
+  console.log(err,result)
+});
+```
+
+Should log something like:
+
+```bash
+null { block:
+ { parentid: '0000000000000000000000000000000000000000000000000000000000000000',
+   nonce: [ 0, 0, 0, 0, 0, 0, 0, 0 ],
+   timestamp: 1433600000,
+   minerpayouts: null,
+   transactions: [ [Object] ] } }
 ```
 
 ## License

--- a/js/sia.js
+++ b/js/sia.js
@@ -171,11 +171,11 @@ function SiadWrapper () {
    * @param {callback} callback - returns if siad is running
    */
   function configure (settings, callback) {
-    siad.path = settings.siad.path || siad.path
-    siad.address = settings.siad.address || siad.address
-    siad.command = settings.siad.command || siad.command
-    if (typeof callback === 'function') {
-      callback(settings)
+    siad.path = settings.path || siad.path
+    siad.address = settings.address || siad.address
+    siad.command = settings.command || siad.command
+    if (callback !== undefined) {
+      callback(null, siad)
     }
   }
 

--- a/js/sia.js
+++ b/js/sia.js
@@ -172,7 +172,7 @@ function DaemonManager () {
     siad.address = settings.siad.address || siad.address
     siad.command = settings.siad.command || siad.command
     if (typeof callback === 'function') {
-      callback()
+      callback(settings)
     }
   }
 

--- a/js/sia.js
+++ b/js/sia.js
@@ -171,9 +171,11 @@ function SiadWrapper () {
    * @param {callback} callback - returns if siad is running
    */
   function configure (settings, callback) {
-    siad.path = settings.path || siad.path
-    siad.address = settings.address || siad.address
-    siad.command = settings.command || siad.command
+    for (var key in settings) {
+      if (siad.hasOwnProperty(key)) {
+        siad[key] = settings[key] || siad[key]
+      }
+    }
     if (callback !== undefined) {
       callback(null, siad)
     }

--- a/js/sia.js
+++ b/js/sia.js
@@ -9,11 +9,11 @@ const Util = require('util')
 const EventEmitter = require('events')
 
 /**
- * DaemonManager, a closure, initializes siad as a background process and
+ * SiadWrapper, a closure, initializes siad as a background process and
  * provides functions to interact with it
- * @class DaemonManager
+ * @class SiadWrapper
  */
-function DaemonManager () {
+function SiadWrapper () {
   // siad details with default values
   var siad = {
     path: Path.join(__dirname, 'Sia'),
@@ -33,7 +33,7 @@ function DaemonManager () {
 
   /**
    * Relays calls to daemonAPI with the localhost:port address appended
-   * @function DaemonManager#apiCall
+   * @function SiadWrapper#apiCall
    * @param {apiCall} call - function to run if Siad is running
    * @param {apiResponse} callback
    */
@@ -80,7 +80,7 @@ function DaemonManager () {
 
   /**
    * Checks whether siad is running and runs ones of two callbacks
-   * @function DaemonManager#ifSiadRunning
+   * @function SiadWrapper#ifSiadRunning
    * @param {callback} is - called if siad is running
    * @param {callback} not - called if siad is not running
    */
@@ -96,7 +96,7 @@ function DaemonManager () {
 
   /**
    * Synchronous way to check if siad is running, may not be up to date
-   * @function DaemonManager#isRunning
+   * @function SiadWrapper#isRunning
    * @returns {boolean} whether siad is running
    */
   function isSiadRunning () {
@@ -205,6 +205,6 @@ function DaemonManager () {
 }
 
 // Inherit functions from `EventEmitter`'s prototype
-Util.inherits(DaemonManager, EventEmitter)
+Util.inherits(SiadWrapper, EventEmitter)
 
-module.exports = new DaemonManager()
+module.exports = new SiadWrapper()

--- a/js/sia.js
+++ b/js/sia.js
@@ -65,10 +65,10 @@ function DaemonManager () {
   }
 
   // Checks whether siad is running on the current address
-  function checkRunning (callback) {
+  function checkIfSiadRunning (callback) {
     apiCall('/daemon/version', function (err) {
       // There should be no reason this call would error if siad were running
-        // and serving requests
+      // and serving requests
       siad.running = !err
 
       // Return result to callback
@@ -85,7 +85,7 @@ function DaemonManager () {
    * @param {callback} not - called if siad is not running
    */
   function ifSiadRunning (is, not) {
-    checkRunning(function (running) {
+    checkIfSiadRunning(function (running) {
       if (running && typeof is === 'function') {
         is()
       } else if (typeof not === 'function') {
@@ -100,7 +100,7 @@ function DaemonManager () {
    * @returns {boolean} whether siad is running
    */
   function isSiadRunning () {
-    checkRunning()
+    checkIfSiadRunning()
     return siad.running
   }
 
@@ -131,11 +131,10 @@ function DaemonManager () {
     var daemonProcess = new Process(siad.command, processOptions)
 
     // Listen for siad erroring
-    // TODO: How to change this error to give more accurate hint. Does
-    // this work?
     daemonProcess.on('error', function (error) {
-      if (error === 'Error: spawn ' + siad.command + ' ENOENT') {
-        error.message = 'Missing siad!'
+      // Clarify that ENOENT errors means siad wasn't at its supposed path
+      if (error.message === 'spawn ' + siad.command + ' ENOENT') {
+        error.message = 'siad not found at ' + siad.path
       }
       self.emit('error', error)
     })


### PR DESCRIPTION
- stop() wasn't calling its callback before
- start() now callbacks an error message when siad isn't found using fs
- clarified a bunch of comments
- DaemonManager is now SiadWrapper (call it how it is)
- Expanded README to have brief usage examples. Will need to solidify various features before devoting time to documenting more fully.
