### PR TITLE
Loud callbacks

### DIFF
--- a/js/download.js
+++ b/js/download.js
@@ -73,5 +73,6 @@ module.exports = function (output, callback) {
               path.join(outputPath, outputDir),
               callback)
   })
+  return true
 }
 

--- a/js/sia.js
+++ b/js/sia.js
@@ -190,11 +190,17 @@ function SiadWrapper () {
    */
   function configure (settings, callback) {
     for (var key in settings) {
+      // Set passed in settings within siad
+      if (settings.hasOwnProperty(key)) {
+        siad[key] = settings[key]
+      }
+      // Modify passed in settings to be in sync with siad
       if (siad.hasOwnProperty(key)) {
-        siad[key] = settings[key] || siad[key]
+        settings[key] = siad[key]
       }
     }
-    checkIfSiadRunning(function () {
+    checkIfSiadRunning(function (check) {
+      settings.running = check
       if (callback !== undefined) {
         callback(null, siad)
       }

--- a/js/sia.js
+++ b/js/sia.js
@@ -17,7 +17,7 @@ function SiadWrapper () {
   var siad = {
     path: require('path').join(__dirname, '..', 'Sia'),
     address: 'http://localhost:9980',
-    command: process.platform === 'win32' ? 'siad.exe' : 'siad',
+    fileName: process.platform === 'win32' ? 'siad.exe' : 'siad',
     headers: {
       'User-Agent': 'Sia-Agent'
     },
@@ -135,7 +135,7 @@ function SiadWrapper () {
       cwd: siad.path
     }
     const Process = require('child_process').spawn
-    var daemonProcess = new Process(siad.command, processOptions)
+    var daemonProcess = new Process(siad.fileName, processOptions)
 
     // Listen for siad erroring
     daemonProcess.on('error', function (error) {

--- a/js/sia.js
+++ b/js/sia.js
@@ -159,8 +159,6 @@ function SiadWrapper () {
 
     // Wait until siad finishes loading to call callback
     waitUntilLoaded(callback)
-
-    // return that we attempted to start siad
     return true
   }
 
@@ -178,13 +176,13 @@ function SiadWrapper () {
         callback(err)
       }
     })
-
-    // return that we attempted to stop siad
     return true
   }
 
   /**
-   * Sets the member variables based on the passed config
+   * Sets the member variables based on the passed config. Checks if siad is
+   * running on the new configuration so siad.running should be up to date for
+   * the callback
    * @param {config} c - the config object derived from config.json
    * @param {callback} callback - first argument is any errors, second argument
    * is the new configuration
@@ -196,9 +194,11 @@ function SiadWrapper () {
         siad[key] = settings[key] || siad[key]
       }
     }
-    if (callback !== undefined) {
-      callback(null, siad)
-    }
+    checkIfSiadRunning(function () {
+      if (callback !== undefined) {
+        callback(null, siad)
+      }
+    })
     return siad
   }
 

--- a/js/sia.js
+++ b/js/sia.js
@@ -50,19 +50,19 @@ function SiadWrapper () {
 
     // Return the request sent if the user wants to be creative and get more
     // information than what's passed to the callback
-    return new Request(call, function (error, response, body) {
+    return new Request(call, function (err, response, body) {
       // The error from Request should be null if siad is running
-      siad.running = !error
+      siad.running = !err
 
       // If siad puts out an error, pass it as first argument to callback
-      if (!error && response.statusCode !== 200) {
-        error = body
+      if (!err && response.statusCode !== 200) {
+        err = body
         body = null
       }
 
       // Return results to callback
       if (callback !== undefined) {
-        callback(error, body)
+        callback(err, body)
       }
     })
   }
@@ -149,8 +149,8 @@ function SiadWrapper () {
 
     // Listen for siad erroring
     // TODO: Attach these to siad if it's already running
-    daemonProcess.on('error', function (error) {
-      self.emit('error', error)
+    daemonProcess.on('error', function (err) {
+      self.emit('error', err)
     })
     daemonProcess.on('exit', function (code) {
       siad.running = false


### PR DESCRIPTION
On top of #8

All public functions return something. Even if the functions use callbacks, they'll evaluate to `undefined` without a explicit return value so I thought it's just added functionality to return stuff.

Callbacks would be checked like so:

``` js
if (typeof callback === 'function') {
    callback();
}
```

but I thought it would be better to have it error on anything besides undefined:

``` js
if (callback !== undefined) {
    callback();
}
```

to alert to the user that something improper is being done.
