### PR TITLE
Set object passed into configure() have siad properties

### DIFF
--- a/js/sia.js
+++ b/js/sia.js
@@ -218,10 +218,13 @@ function SiadWrapper () {
    * @returns {object} siad configuration object
    */
   function configure (settings, callback) {
-    for (let key in settings) {
+    for (let key in siad) {
       // Set passed in settings within siad
-      if (siad.hasOwnProperty(key)) {
+      if (siad.hasOwnProperty(key) && settings.hasOwnProperty(key)) {
         siad[key] = settings[key]
+      } else if (siad.hasOwnProperty(key)) {
+        // Set settings to sync with siad
+        settings[key] = siad[key]
       }
     }
     checkIfSiadRunning(function (check) {


### PR DESCRIPTION
This way, a settings plugin in the UI could see these members and mess with them.

Cuz we expose the siad object's members.

Exposing our members can't hurt, right? :wink:
