### PR TITLE
only throw errors for non-2xx status codes

### DIFF
--- a/src/sia.js
+++ b/src/sia.js
@@ -32,7 +32,7 @@ const call = (address, opts) => new Promise((resolve, reject) => {
 	}
 
 	request(callOptions, (err, res, body) => {
-		if (!err && res.statusCode !== 200) {
+		if (!err && (res.statusCode < 200 || res.statusCode > 299)) {
 			reject(body)
 		} else if (!err) {
 			resolve(body)
@@ -73,6 +73,7 @@ async function isRunning(address) {
 		await call(address, '/daemon/version')
 		return true
 	} catch (e) {
+		console.error(e.toString())
 		return false
 	}
 }

--- a/src/sia.js
+++ b/src/sia.js
@@ -67,13 +67,14 @@ const launch = (path, settings) => {
 }
 
 // isRunning returns true if a successful call can be to /daemon/version
-// using the address provided in `address`.
+// using the address provided in `address`.  Note that this call does not check
+// whether the siad process is still running, it only checks if a Sia API is
+// reachable.
 async function isRunning(address) {
 	try {
 		await call(address, '/daemon/version')
 		return true
 	} catch (e) {
-		console.error(e.toString())
 		return false
 	}
 }


### PR DESCRIPTION
this pr changes the semantics of `Siad.call` such that it will only throw an error if the response status code is non-2xx (previously all non-200 errors triggered an error).
