### PR TITLE
query /gateway instead of /daemon/version to determine isRunning

### DIFF
--- a/src/sia.js
+++ b/src/sia.js
@@ -66,13 +66,13 @@ const launch = (path, settings) => {
 	return spawn(path, flags, opts)
 }
 
-// isRunning returns true if a successful call can be to /daemon/version
+// isRunning returns true if a successful call can be to /gateway
 // using the address provided in `address`.  Note that this call does not check
 // whether the siad process is still running, it only checks if a Sia API is
 // reachable.
 async function isRunning(address) {
 	try {
-		await call(address, '/daemon/version')
+		await call(address, '/gateway')
 		return true
 	} catch (e) {
 		return false

--- a/test/sia.js
+++ b/test/sia.js
@@ -53,14 +53,14 @@ describe('sia.js wrapper library', () => {
 		describe('isRunning', () => {
 			it('returns true when siad is running', async function() {
 				nock('http://localhost:9980')
-				  .get('/daemon/version')
-				  .reply(200, 'test-version')
+				  .get('/gateway')
+				  .reply(200, 'success')
 				const running = await isRunning('localhost:9980')
 				expect(running).to.be.true
 			})
 			it('returns false when siad is not running', async function() {
 				nock('http://localhost:9980')
-				  .get('/daemon/version')
+				  .get('/gateway')
 				  .replyWithError('error')
 				const running = await isRunning('localhost:9980')
 				expect(running).to.be.false
@@ -69,7 +69,7 @@ describe('sia.js wrapper library', () => {
 		describe('connect', () => {
 			it('throws an error if siad is unreachable', async function() {
 				nock('http://localhost:9980')
-				  .get('/daemon/version')
+				  .get('/gateway')
 				  .replyWithError('test-error')
 				let didThrow = false
 				let err
@@ -86,19 +86,19 @@ describe('sia.js wrapper library', () => {
 			let siad
 			it('returns a valid siad object if sia is reachable', async function() {
 				nock('http://localhost:9980')
-				  .get('/daemon/version')
-				  .reply(200, 'test-version')
+				  .get('/gateway')
+				  .reply(200, 'success')
 				siad = await connect('localhost:9980')
 				expect(siad).to.have.property('call')
 				expect(siad).to.have.property('isRunning')
 			})
 			it('can make api calls using siad.call', async function() {
 				nock('http://localhost:9980')
-				  .get('/daemon/version')
-				  .reply(200, 'test-version')
+				  .get('/gateway')
+				  .reply(200, 'success')
 
-				const version = await siad.call('/daemon/version')
-				expect(version).to.equal('test-version')
+				const gateway = await siad.call('/gateway')
+				expect(gateway).to.equal('success')
 			})
 		})
 		describe('call', () => {


### PR DESCRIPTION
this PR changes `isRunning` to query the `/gateway` endpoint in order to determine if a Sia API is available. Previously, it used `/daemon/version`, which becomes available before the API.
