### PR TITLE
redirect stderr and stdout to sia-directory if it exists

### DIFF
--- a/src/sia.js
+++ b/src/sia.js
@@ -3,10 +3,12 @@
 import BigNumber from 'bignumber.js'
 import fs from 'fs'
 import { spawn } from 'child_process'
+import Path from 'path'
 import request from 'request'
 
 // sia.js error constants
 export const errCouldNotConnect = new Error('could not connect to the Sia daemon')
+export const minimumVersion = '1.0.3'
 
 // Siacoin -> hastings unit conversion functions
 // These make conversion between units of Sia easy and consistent for developers.
@@ -60,7 +62,13 @@ const launch = (path, settings) => {
 	const mapFlags = (key) => '--' + key + '=' + mergedSettings[key]
 	const flags = Object.keys(mergedSettings).filter(filterFlags).map(mapFlags)
 
-	const siadOutput = fs.openSync('./siad-output.log', 'a')
+	const siadOutput = (() => {
+		if (typeof mergedSettings['sia-directory'] !== 'undefined') {
+			return fs.openSync(Path.join(mergedSettings['sia-directory'], './siad-output.log'), 'a')
+		}
+		return fs.openSync('./siad-output.log', 'a')
+	})()
+
 	const opts = {
 		'stdio': [ process.stdin, siadOutput, siadOutput ],
 	}

--- a/src/sia.js
+++ b/src/sia.js
@@ -64,9 +64,9 @@ const launch = (path, settings) => {
 
 	const siadOutput = (() => {
 		if (typeof mergedSettings['sia-directory'] !== 'undefined') {
-			return fs.openSync(Path.join(mergedSettings['sia-directory'], './siad-output.log'), 'a')
+			return fs.openSync(Path.join(mergedSettings['sia-directory'], './siad-output.log'), 'w')
 		}
-		return fs.openSync('./siad-output.log', 'a')
+		return fs.openSync('./siad-output.log', 'w')
 	})()
 
 	const opts = {

--- a/src/sia.js
+++ b/src/sia.js
@@ -8,7 +8,6 @@ import request from 'request'
 
 // sia.js error constants
 export const errCouldNotConnect = new Error('could not connect to the Sia daemon')
-export const minimumVersion = '1.0.3'
 
 // Siacoin -> hastings unit conversion functions
 // These make conversion between units of Sia easy and consistent for developers.

--- a/test/sia.js
+++ b/test/sia.js
@@ -6,6 +6,7 @@ import { expect } from 'chai'
 import proxyquire from 'proxyquire'
 import { spy } from 'sinon'
 import nock from 'nock'
+import fs from 'fs'
 // Mock the process calls required for testing Siad launch functionality.
 const mock = {
 	'child_process': {
@@ -151,6 +152,13 @@ describe('sia.js wrapper library', () => {
 			it('starts siad with --sia-directory given sia-directory', () => {
 				const testSettings = {
 					'sia-directory': 'testdir',
+				}
+				try {
+					fs.mkdirSync('./testdir')
+				} catch (e) {
+					if (e.code !== 'EEXIST') {
+						throw e
+					}
 				}
 				launch('testpath', testSettings)
 				expect(mock['child_process'].spawn.called).to.be.true


### PR DESCRIPTION
This PR is in preparation to the loggin plugin PR in the UI. it redirects siad's stderr and stdout to `siad-output` inside the `sia-directory`, whereas before it was output to `./siad-output`, in the working directory.