### PR TITLE
use createWriteStream to pipe siad output instead of openSync

### DIFF
--- a/src/sia.js
+++ b/src/sia.js
@@ -66,18 +66,19 @@ const launch = (path, settings) => {
 
 	const siadOutput = (() => {
 		if (typeof mergedSettings['sia-directory'] !== 'undefined') {
-			return fs.openSync(Path.join(mergedSettings['sia-directory'], './siad-output.log'), 'w')
+			return fs.createWriteStream(Path.join(mergedSettings['sia-directory'], 'siad-output.log'))
 		}
-		return fs.openSync('./siad-output.log', 'w')
+		return fs.createWriteStream('siad-output.log')
 	})()
 
-	const opts = {
-		'stdio': [ process.stdin, siadOutput, siadOutput ],
-	}
+	const opts = { }
 	if (process.geteuid) {
 		opts.uid = process.geteuid()
 	}
-	return spawn(path, flags, opts)
+	const siadProcess = spawn(path, flags, opts)
+	siadProcess.stdout.pipe(siadOutput)
+	siadProcess.stderr.pipe(siadOutput)
+	return siadProcess
 }
 
 // isRunning returns true if a successful call can be to /gateway


### PR DESCRIPTION
This PR fixes an issue on Windows introduced in the stdout/stderr logging PR. Passing the return value of `openSync` to `opts.stdout` does not work on windows, so this PR creates an output write stream and pipes the child process's output to that stream.