### PR TITLE
10 minute requst timeout for isRunning

### DIFF
--- a/src/sia.js
+++ b/src/sia.js
@@ -98,7 +98,10 @@ const launch = (path, settings) => {
 // reachable.
 async function isRunning(address) {
 	try {
-		await call(address, '/gateway')
+		await call(address, {
+			url: '/gateway',
+			timeout: 6e5, // 10 minutes
+		})
 		return true
 	} catch (e) {
 		return false


### PR DESCRIPTION
This PR adds a long timeout for the `isRunning` call, to avoid interpreting a delay of >10 seconds as a stoppage of Siad in the UI.