### PR TITLE
remove default `modules` flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sia.js",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Node wrapper for siad of the Sia network",
   "repository": {
     "type": "git",

--- a/src/sia.js
+++ b/src/sia.js
@@ -68,7 +68,6 @@ const launch = (path, settings) => {
 		'rpc-addr': ':9981',
 		'authenticate-api': false,
 		'disable-api-security': false,
-		'modules': 'cghmrtw',
 	}
 	const mergedSettings = Object.assign(defaultSettings, settings)
 	const filterFlags = (key) => mergedSettings[key] !== false

--- a/test/sia.js
+++ b/test/sia.js
@@ -150,7 +150,6 @@ describe('sia.js wrapper library', () => {
 					'--api-addr=localhost:9980',
 					'--host-addr=:9982',
 					'--rpc-addr=:9981',
-					'--modules=cghmrtw',
 				]
 				launch('testpath')
 				expect(mock['child_process'].spawn.called).to.be.true


### PR DESCRIPTION
This PR removes sia.js's default `modules` flags, in favor of allowing `siad` to select the default modules.