### PR TITLE
Configurable request limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sia.js",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Node wrapper for siad of the Sia network",
   "repository": {
     "type": "git",

--- a/src/sia.js
+++ b/src/sia.js
@@ -128,7 +128,7 @@ async function connect(address) {
 
 // setConcurrentRequestLimit limits the number of in-flight http requests,
 // useful for applications that do lots of polling.
-export const setConcurrentRequestLimit = (nrequests) => {
+const setConcurrentRequestLimit = (nrequests) => {
 	requestQueue = rqueue(nrequests)
 }
 
@@ -139,4 +139,5 @@ export {
 	call,
 	siacoinsToHastings,
 	hastingsToSiacoins,
+	setConcurrentRequestLimit,
 }

--- a/src/sia.js
+++ b/src/sia.js
@@ -6,8 +6,8 @@ import { spawn } from 'child_process'
 import Path from 'path'
 import rqueue from 'http-request-queue'
 
-const concurrentRequestLimit = 100
-const request = rqueue(concurrentRequestLimit).request
+const defaultConcurrentRequestLimit = 40
+let requestQueue = rqueue(defaultConcurrentRequestLimit)
 
 // sia.js error constants
 export const errCouldNotConnect = new Error('could not connect to the Sia daemon')
@@ -48,7 +48,7 @@ const call = async (address, opts) => {
 	const callOptions = makeRequest(address, opts)
 
 	try {
-		const res = await request(callOptions)
+		const res = await requestQueue.request(callOptions)
 		if (res.response.statusCode < 200 || res.response.statusCode > 299) {
 			throw res.body
 		}
@@ -124,6 +124,12 @@ async function connect(address) {
 		throw errCouldNotConnect
 	}
 	return siadWrapper(address)
+}
+
+// setConcurrentRequestLimit limits the number of in-flight http requests,
+// useful for applications that do lots of polling.
+export const setConcurrentRequestLimit = (nrequests) => {
+	requestQueue = rqueue(nrequests)
 }
 
 export {


### PR DESCRIPTION
This PR adds a method to sia.js, `setConcurrentRequestLimit`, allowing callers to specify how large the request queue should be. It also reduces the default size from 100 to 40. Should fix the problems mentioned by mac users here https://github.com/NebulousLabs/Sia/issues/1702