### PR TITLE
pool httprequests, reusing existing connections and preventing socket usage from exceeding 40

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "babel-runtime": "^6.23.0",
     "bignumber.js": "^2.3.0",
     "eslint": "^3.19.0",
-    "http-request-queue": "^0.1.0",
     "request": "^2.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "mocha": "^2.5.3",
     "nock": "^8.0.0",
     "proxyquire": "^1.7.10",
+    "readdir": "0.0.13",
     "sinon": "^1.17.4"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sia.js",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "Node wrapper for siad of the Sia network",
   "repository": {
     "type": "git",

--- a/src/sia.js
+++ b/src/sia.js
@@ -4,10 +4,13 @@ import BigNumber from 'bignumber.js'
 import fs from 'fs'
 import { spawn } from 'child_process'
 import Path from 'path'
-import rqueue from 'http-request-queue'
+import request from 'request'
+import http from 'http'
 
-const defaultConcurrentRequestLimit = 40
-let requestQueue = rqueue(defaultConcurrentRequestLimit)
+const reqPool = new http.Agent({
+	keepAlive: true,
+	maxSockets: 40,
+})
 
 // sia.js error constants
 export const errCouldNotConnect = new Error('could not connect to the Sia daemon')
@@ -37,6 +40,7 @@ export const makeRequest = (address, opts) => {
 	callOptions.headers = {
 		'User-Agent': 'Sia-Agent',
 	}
+	callOptions.pool = reqPool
 
 	return callOptions
 }
@@ -44,19 +48,18 @@ export const makeRequest = (address, opts) => {
 // Call makes a call to the Sia API at `address`, with the request options defined by `opts`.
 // returns a promise which resolves with the response if the request completes successfully
 // and rejects with the error if the request fails.
-const call = async (address, opts) => {
+const call = (address, opts) => new Promise((resolve, reject) => {
 	const callOptions = makeRequest(address, opts)
-
-	try {
-		const res = await requestQueue.request(callOptions)
-		if (res.response.statusCode < 200 || res.response.statusCode > 299) {
-			throw res.body
+	request(callOptions, (err, res, body) => {
+		if (!err && (res.statusCode < 200 || res.statusCode > 299)) {
+			reject(body)
+		} else if (!err) {
+			resolve(body)
+		} else {
+			reject(err)
 		}
-		return res.body
-	} catch (e) {
-		throw e
-	}
-}
+	})
+})
 
 // launch launches a new instance of siad using the flags defined by `settings`.
 // this function can `throw`, callers should catch errors.
@@ -125,12 +128,6 @@ async function connect(address) {
 	return siadWrapper(address)
 }
 
-// setConcurrentRequestLimit limits the number of in-flight http requests,
-// useful for applications that do lots of polling.
-const setConcurrentRequestLimit = (nrequests) => {
-	requestQueue = rqueue(nrequests)
-}
-
 export {
 	connect,
 	launch,
@@ -138,5 +135,4 @@ export {
 	call,
 	siacoinsToHastings,
 	hastingsToSiacoins,
-	setConcurrentRequestLimit,
 }

--- a/src/sia.js
+++ b/src/sia.js
@@ -7,9 +7,9 @@ import Path from 'path'
 import request from 'request'
 import http from 'http'
 
-const reqPool = new http.Agent({
+const agent = new http.Agent({
 	keepAlive: true,
-	maxSockets: 40,
+	maxSockets: 20,
 })
 
 // sia.js error constants
@@ -40,7 +40,7 @@ export const makeRequest = (address, opts) => {
 	callOptions.headers = {
 		'User-Agent': 'Sia-Agent',
 	}
-	callOptions.pool = reqPool
+	callOptions.pool = agent
 
 	return callOptions
 }
@@ -135,4 +135,5 @@ export {
 	call,
 	siacoinsToHastings,
 	hastingsToSiacoins,
+	agent,
 }

--- a/test/sia.js
+++ b/test/sia.js
@@ -121,7 +121,7 @@ describe('sia.js wrapper library', () => {
 						'User-Agent': 'Sia-Agent',
 					},
 				}
-				expect(makeRequest('localhost:9980', '/test')).to.deep.equal(expectedOpts)
+				expect(makeRequest('localhost:9980', '/test')).to.contain.keys(expectedOpts)
 			})
 			it('constructs the correct request options given an object parameter', () => {
 				const testparams = {
@@ -136,7 +136,7 @@ describe('sia.js wrapper library', () => {
 					timeout: 10000,
 					json: true,
 				}
-				expect(makeRequest('localhost:9980', { url: '/test', qs: testparams })).to.deep.equal(expectedOpts)
+				expect(makeRequest('localhost:9980', { url: '/test', qs: testparams })).to.contain.keys(expectedOpts)
 			})
 		})
 		describe('launch', () => {


### PR DESCRIPTION
This PR removes `rqueue` in favor of using a `http.Agent`, using `KeepAlive` to reuse connections and a `maxSockets` of 40. I verified that `Sia-UI` was leaking file descriptors before this change, and with this change no longer leaks. This should fix the reports of crashing on Fedora and OSX mentioned here: https://github.com/NebulousLabs/Sia/issues/1750 and elsewhere.

Since this is a major bugfix, I bumped the version to 0.4.0.