### PR TITLE
Change babel-runtime to build dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-3": "^6.11.0",
     "babel-register": "^6.18.0",
-    "babel-runtime": "^6.18.0",
     "chai": "^4.1.2",
     "eslint": "4.7.2",
     "mocha": "^3.5.3",
@@ -48,6 +47,7 @@
   },
   "dependencies": {
     "bignumber.js": "^4.0.4",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "babel-runtime": "^6.18.0"
   }
 }


### PR DESCRIPTION
This fixes issue #49 

babel-runtime needs to be included under dependencies rather than devDependencies so that the runtime package is included in the actual build lib.